### PR TITLE
Add styling for focused cards; Add card click handling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -55,6 +55,11 @@ html, body, #app {
   position: relative;
 }
 
+#game-board > div > div.focused {
+  box-shadow: 0 0 10px 10px #0ff;
+  z-index: 3;
+}
+
 #game-board > div > div > .chip {
   position: absolute;
   top: 0;
@@ -67,6 +72,12 @@ html, body, #app {
   height: 14vh;
   margin: 0.5vh -4vh 0 0;
   transform: rotate(2deg);
+}
+
+#player-cards > div.focused {
+  margin-top: -1vh;
+  width: 11vh;
+  height: 15vh;
 }
 
 #game-board > div > div > *, #player-cards > div > * {

--- a/index.html
+++ b/index.html
@@ -27,10 +27,12 @@
 
   <div id="app">
     <div id="desk">
-      <game-board id="game-board" :card-state-rows="boardCardStateRows"></game-board>
+      <game-board id="game-board" @card-click="boardCardClick"
+        :card-state-rows="boardCardStateRows" :game-state="gameState"></game-board>
     </div>
     <div id="player">
-      <card-hand id="player-cards" :card-states="handCardStates"></card-hand>
+      <card-hand id="player-cards" @card-click="handCardClick"
+        :card-states="handCardStates" :game-state="gameState"></card-hand>
     </div>
   </div>
 


### PR DESCRIPTION
css/styles.css
 - add focus styling for on-board/in-hand cards

index.html
 - bind "card-click" event handlers and "game-state" properties

js/app.js
 - CardSlot: add "focusedCard" property and "cardClick" event; add "focused" to class if the card matches "focusedCard"
 - CardHand/GameBoard: add "gameState" property and "cardClick" event; pass through "gameState.focusedCard" to CardSlot
 - app: add "gameState" data and "handCardClick"/"boardCardClick" event handler methods
 - use shorthand syntax in component declarations